### PR TITLE
Use octal for directory permissions

### DIFF
--- a/ap/commands/login.py
+++ b/ap/commands/login.py
@@ -58,7 +58,7 @@ class LoginCommand(Command):
     def save_token(self, token):
         apdir = Path(self.env.get("HOME")) / ".ap"
         if not apdir.exists():
-            apdir.mkdir(700)
+            apdir.mkdir(0o700)
         data = {"actor_id": self.actor_id, **token}
         with open(apdir / "token.json", "w") as f:
             f.write(json.dumps(data))


### PR DESCRIPTION
The `.ap` directory was being created with strange permissions. Changing `700` from decimal to octal makes it behave more logically.
